### PR TITLE
Fix type confusion due to translation issues in the first chapter

### DIFF
--- a/capitulos/chap01.ipynb
+++ b/capitulos/chap01.ipynb
@@ -1016,7 +1016,7 @@
         "entre grupos de dígitos, como em `1,000,000`.\n",
         "Esta é uma expressão legal em Python, mas o resultado não é um inteiro:\n",
         "\n",
-        "NOTA DO TRADUTOR: os números em Python seguem a conveção da língua inglesa em que o separador decimal é um ponto e o separador de milhar é uma vírgula."
+        "NOTA DO TRADUTOR: os números em Python seguem a conveção da língua inglesa em que o separador decimal é um ponto."
       ]
     },
     {
@@ -1038,7 +1038,7 @@
         "id": "3d24af71"
       },
       "source": [
-        "Python interpreta `1.000.000` como uma sequência de inteiros separados por vírgulas.\n",
+        "Python interpreta `1,000,000` como uma sequência de inteiros separados por vírgulas.\n",
         "Aprenderemos mais sobre esse tipo de sequência mais tarde.\n",
         "\n",
         "Você pode usar sublinhados para tornar números grandes mais fáceis de ler:"


### PR DESCRIPTION
This commit fix a "type confusion" due to translation issue in the first chapter inside `Valores e tipos` section.
In Python, a comma is not used to separate thousands like it is used in english. The example shows that something like `a = 1,000,000` creates valid python code, but not with the same meaning as in engish.
The example creates a tuple with three integer elements, e.g.:
```
>>> a = 1,000,000
>>> a
(1, 0, 0)
>>> type(a)
<class 'tuple'>
```

This commit removes part of translation note that could generate confusion among readers, it also changes the number `1.000.000` (which is a float in python) back to `1,000,000` so it can be a tuple.